### PR TITLE
fixes #725 

### DIFF
--- a/mailscanner/functions.php
+++ b/mailscanner/functions.php
@@ -1608,8 +1608,8 @@ function parse_conf_dir($conf_dir)
     $array_output1 = array();
     if ($dh = opendir($conf_dir)) {
         while (($file = readdir($dh)) !== false) {
-            // remove the . and .. so that it doesn't throw an error when parsing files
-            if ($file !== '.' && $file !== '..') {
+            // ignore subfolders and hidden files so that it doesn't throw an error when parsing files
+            if (strlen($file) > 0 &&  substr($file, 0, 1) !== '.' && is_file($conf_dir . $file) ) {
                 $file_name = $conf_dir . $file;
                 if (!is_array($array_output1)) {
                     $array_output1 = parse_conf_file($file_name);

--- a/mailscanner/functions.php
+++ b/mailscanner/functions.php
@@ -1609,7 +1609,7 @@ function parse_conf_dir($conf_dir)
     if ($dh = opendir($conf_dir)) {
         while (($file = readdir($dh)) !== false) {
             // ignore subfolders and hidden files so that it doesn't throw an error when parsing files
-            if (strlen($file) > 0 &&  substr($file, 0, 1) !== '.' && is_file($conf_dir . $file) ) {
+            if (strlen($file) > 0 &&  substr($file, 0, 1) !== '.' && is_file($conf_dir . $file)) {
                 $file_name = $conf_dir . $file;
                 if (!is_array($array_output1)) {
                     $array_output1 = parse_conf_file($file_name);


### PR DESCRIPTION
Ignore MailScanner config files (of conf.d/*) in subfolders and hidden files (starting with `.` )