### PR TITLE
Fixes session conflict

### DIFF
--- a/mailscanner/bayes_info.php
+++ b/mailscanner/bayes_info.php
@@ -32,11 +32,6 @@
 // Require the functions page
 require_once __DIR__ . '/functions.php';
 
-// Start the session
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 // Require the login function code
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/bayes_info.php
+++ b/mailscanner/bayes_info.php
@@ -33,6 +33,9 @@
 require_once __DIR__ . '/functions.php';
 
 // Start the session
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 // Require the login function code
 require __DIR__ . '/login.function.php';

--- a/mailscanner/checklogin.php
+++ b/mailscanner/checklogin.php
@@ -33,6 +33,9 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/lib/password.php';
 require_once __DIR__ . '/lib/hash_equals.php';
 disableBrowserCache();
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 if (isset($_POST['token'])) {
     if (false === checkToken($_POST['token'])) {

--- a/mailscanner/checklogin.php
+++ b/mailscanner/checklogin.php
@@ -33,10 +33,7 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/lib/password.php';
 require_once __DIR__ . '/lib/hash_equals.php';
 disableBrowserCache();
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
+
 if (isset($_POST['token'])) {
     if (false === checkToken($_POST['token'])) {
         die(__('dietoken99'));

--- a/mailscanner/clamav_status.php
+++ b/mailscanner/clamav_status.php
@@ -32,11 +32,6 @@
 // Require the functions page
 require_once __DIR__ . '/functions.php';
 
-// Start the session
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 // Require the login function code
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/clamav_status.php
+++ b/mailscanner/clamav_status.php
@@ -33,6 +33,9 @@
 require_once __DIR__ . '/functions.php';
 
 // Start the session
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 // Require the login function code
 require __DIR__ . '/login.function.php';

--- a/mailscanner/conf.php.example
+++ b/mailscanner/conf.php.example
@@ -39,6 +39,11 @@ define('DEBUG', false);
 // Define language (de, en, fr, it, nl, pt_br);
 define('LANG', 'en');
 
+//Session Handling - conflicts can exist when the your environment makes use of multiple php sessions on the same server
+// to resolve this, uncomment the following option.  See https://github.com/mailwatch/MailWatch/issues/730 for more info
+//define('SESSION_NAME', 'MailWatch');
+
+
 // Database settings
 //
 // As this file might be publically readable. It might be very userful to

--- a/mailscanner/detail.php
+++ b/mailscanner/detail.php
@@ -32,11 +32,6 @@
 // Require the functions page
 require_once __DIR__ . '/functions.php';
 
-// Start the session
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 // Require the login function code
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/detail.php
+++ b/mailscanner/detail.php
@@ -33,6 +33,9 @@
 require_once __DIR__ . '/functions.php';
 
 // Start the session
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 // Require the login function code
 require __DIR__ . '/login.function.php';

--- a/mailscanner/do_message_ops.php
+++ b/mailscanner/do_message_ops.php
@@ -31,10 +31,7 @@
 
 require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
+
 require __DIR__ . '/login.function.php';
 
 $refresh = html_start(__('opresult21'));

--- a/mailscanner/do_message_ops.php
+++ b/mailscanner/do_message_ops.php
@@ -31,7 +31,9 @@
 
 require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
-
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/docs.php
+++ b/mailscanner/docs.php
@@ -30,7 +30,9 @@
  */
 
 require_once __DIR__ . '/functions.php';
-
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/docs.php
+++ b/mailscanner/docs.php
@@ -30,10 +30,7 @@
  */
 
 require_once __DIR__ . '/functions.php';
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
+
 require __DIR__ . '/login.function.php';
 
 html_start(__('doc20'));

--- a/mailscanner/f-prot_status.php
+++ b/mailscanner/f-prot_status.php
@@ -32,11 +32,6 @@
 // Include of necessary functions
 require_once __DIR__ . '/functions.php';
 
-// Authentication checking
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 if ($_SESSION['user_type'] !== 'A') {

--- a/mailscanner/f-prot_status.php
+++ b/mailscanner/f-prot_status.php
@@ -33,6 +33,9 @@
 require_once __DIR__ . '/functions.php';
 
 // Authentication checking
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/f-secure_status.php
+++ b/mailscanner/f-secure_status.php
@@ -33,6 +33,9 @@
 require_once __DIR__ . '/functions.php';
 
 // Authentication checking
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/f-secure_status.php
+++ b/mailscanner/f-secure_status.php
@@ -33,10 +33,6 @@
 require_once __DIR__ . '/functions.php';
 
 // Authentication checking
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 if ($_SESSION['user_type'] !== 'A') {

--- a/mailscanner/functions.php
+++ b/mailscanner/functions.php
@@ -126,7 +126,7 @@ if (defined('SESSION_NAME')) {
 }
 session_set_cookie_params(0, $params['path'], $params['domain'], $session_cookie_secure, true);
 unset($session_cookie_secure);
-
+session_start();
 // set default timezone
 date_default_timezone_set(TIME_ZONE);
 

--- a/mailscanner/functions.php
+++ b/mailscanner/functions.php
@@ -4177,6 +4177,7 @@ function checkConfVariables()
         'PWD_RESET_FROM_ADDRESS' => array('description' => 'needed if Password Reset feature is enabled'),
         'MAILQ' => array('description' => 'needed when using Exim or Sendmail to display the inbound/outbound mail queue lengths'),
         'MAIL_SENDER'  => array('description' => 'needed if you use Exim or Sendmail Queue'),
+        'SESSION_NAME' => array('description' => 'needed if experiencing session conflicts')
     );
 
     $neededMissing = array();

--- a/mailscanner/functions.php
+++ b/mailscanner/functions.php
@@ -121,6 +121,9 @@ if (SSL_ONLY === true) {
 
 //enforce session cookie security
 $params = session_get_cookie_params();
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_set_cookie_params(0, $params['path'], $params['domain'], $session_cookie_secure, true);
 unset($session_cookie_secure);
 

--- a/mailscanner/geoip_update.php
+++ b/mailscanner/geoip_update.php
@@ -33,6 +33,9 @@
 require_once __DIR__ . '/functions.php';
 
 // Authentication verification and keep the session alive
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/geoip_update.php
+++ b/mailscanner/geoip_update.php
@@ -32,11 +32,7 @@
 //Require files
 require_once __DIR__ . '/functions.php';
 
-// Authentication verification and keep the session alive
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
+// Authentication verification
 require __DIR__ . '/login.function.php';
 
 html_start(__('geoipupdate15'), 0, false, false);

--- a/mailscanner/lib/pear/Pager/Common.php
+++ b/mailscanner/lib/pear/Pager/Common.php
@@ -1627,6 +1627,9 @@ abstract class Pager_Common
         $this->_perPage = max($this->_perPage, 1); //avoid possible user errors
 
         if ($this->_useSessions && !isset($_SESSION)) {
+            if (defined('SESSION_NAME')) {
+                session_name(SESSION_NAME);
+            }
             session_start();
         }
         if (!empty($_REQUEST[$this->_sessionVar])) {

--- a/mailscanner/lib/pear/Pager/Common.php
+++ b/mailscanner/lib/pear/Pager/Common.php
@@ -1627,10 +1627,7 @@ abstract class Pager_Common
         $this->_perPage = max($this->_perPage, 1); //avoid possible user errors
 
         if ($this->_useSessions && !isset($_SESSION)) {
-            if (defined('SESSION_NAME')) {
-                session_name(SESSION_NAME);
-            }
-            session_start();
+           // session_start();
         }
         if (!empty($_REQUEST[$this->_sessionVar])) {
             $this->_perPage = max(1, (int)$_REQUEST[$this->_sessionVar]);

--- a/mailscanner/lists.php
+++ b/mailscanner/lists.php
@@ -30,7 +30,9 @@
  */
 
 require_once __DIR__ . '/functions.php';
-
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/lists.php
+++ b/mailscanner/lists.php
@@ -30,10 +30,7 @@
  */
 
 require_once __DIR__ . '/functions.php';
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
+
 require __DIR__ . '/login.function.php';
 
 html_start(__('wblists07'), 0, false, false);

--- a/mailscanner/login.php
+++ b/mailscanner/login.php
@@ -33,7 +33,9 @@
 */
 
 require_once __DIR__ . '/functions.php';
-
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 disableBrowserCache();
 session_regenerate_id(true);

--- a/mailscanner/login.php
+++ b/mailscanner/login.php
@@ -33,10 +33,7 @@
 */
 
 require_once __DIR__ . '/functions.php';
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
+
 disableBrowserCache();
 session_regenerate_id(true);
 

--- a/mailscanner/logout.php
+++ b/mailscanner/logout.php
@@ -28,6 +28,7 @@
  * You should have received a copy of the GNU General Public License along with this program; if not, write to the Free
  * Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
+
 require_once __DIR__ . '/functions.php';
 if (defined('SESSION_NAME')) {
     session_name(SESSION_NAME);

--- a/mailscanner/logout.php
+++ b/mailscanner/logout.php
@@ -28,7 +28,10 @@
  * You should have received a copy of the GNU General Public License along with this program; if not, write to the Free
  * Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
-
+require_once __DIR__ . '/functions.php';
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 // reset session variables
 $_SESSION = array();

--- a/mailscanner/logout.php
+++ b/mailscanner/logout.php
@@ -30,10 +30,7 @@
  */
 
 require_once __DIR__ . '/functions.php';
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
+
 // reset session variables
 $_SESSION = array();
 

--- a/mailscanner/mailq.php
+++ b/mailscanner/mailq.php
@@ -30,7 +30,9 @@
  */
 
 require_once __DIR__ . '/functions.php';
-
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/mailq.php
+++ b/mailscanner/mailq.php
@@ -30,10 +30,7 @@
  */
 
 require_once __DIR__ . '/functions.php';
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
+
 require __DIR__ . '/login.function.php';
 
 html_start(__('mqviewer24'), STATUS_REFRESH, false, false);

--- a/mailscanner/mcafee_status.php
+++ b/mailscanner/mcafee_status.php
@@ -33,6 +33,9 @@
 require_once __DIR__ . '/functions.php';
 
 // Authentication checking
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/mcafee_status.php
+++ b/mailscanner/mcafee_status.php
@@ -33,10 +33,6 @@
 require_once __DIR__ . '/functions.php';
 
 // Authentication checking
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 if ($_SESSION['user_type'] !== 'A') {

--- a/mailscanner/mcp_rules_update.php
+++ b/mailscanner/mcp_rules_update.php
@@ -30,7 +30,9 @@
  */
 
 require_once __DIR__ . '/functions.php';
-
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/mcp_rules_update.php
+++ b/mailscanner/mcp_rules_update.php
@@ -30,10 +30,7 @@
  */
 
 require_once __DIR__ . '/functions.php';
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
+
 require __DIR__ . '/login.function.php';
 
 if ($_SESSION['user_type'] !== 'A') {

--- a/mailscanner/ms_lint.php
+++ b/mailscanner/ms_lint.php
@@ -30,7 +30,9 @@
  */
 
 require_once __DIR__ . '/functions.php';
-
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/ms_lint.php
+++ b/mailscanner/ms_lint.php
@@ -30,10 +30,7 @@
  */
 
 require_once __DIR__ . '/functions.php';
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
+
 require __DIR__ . '/login.function.php';
 
 html_start(__('mailscannerlint28'), 0, false, false);

--- a/mailscanner/msconfig.php
+++ b/mailscanner/msconfig.php
@@ -30,7 +30,9 @@
  */
 
 require_once __DIR__ . '/functions.php';
-
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/msconfig.php
+++ b/mailscanner/msconfig.php
@@ -30,10 +30,7 @@
  */
 
 require_once __DIR__ . '/functions.php';
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
+
 require __DIR__ . '/login.function.php';
 
 if ($_SESSION['user_type'] !== 'A') {

--- a/mailscanner/msre_edit.php
+++ b/mailscanner/msre_edit.php
@@ -52,6 +52,9 @@ Released under the GNU GPL: http://www.gnu.org/copyleft/gpl.html#TOC1
 require_once __DIR__ . '/functions.php';
 
 // Authentication checking
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/msre_edit.php
+++ b/mailscanner/msre_edit.php
@@ -52,10 +52,6 @@ Released under the GNU GPL: http://www.gnu.org/copyleft/gpl.html#TOC1
 require_once __DIR__ . '/functions.php';
 
 // Authentication checking
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 // Check to see if the user is an administrator

--- a/mailscanner/msre_index.php
+++ b/mailscanner/msre_index.php
@@ -54,6 +54,9 @@ require_once __DIR__ . '/functions.php';
 include __DIR__ . '/msre_table_functions.php';
 
 // Authentication checking
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 // Check to see if the user is an administrator

--- a/mailscanner/msre_index.php
+++ b/mailscanner/msre_index.php
@@ -54,10 +54,6 @@ require_once __DIR__ . '/functions.php';
 include __DIR__ . '/msre_table_functions.php';
 
 // Authentication checking
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 // Check to see if the user is an administrator
 if ($_SESSION['user_type'] !== 'A') {

--- a/mailscanner/msrule.php
+++ b/mailscanner/msrule.php
@@ -30,7 +30,9 @@
  */
 
 require_once __DIR__ . '/functions.php';
-
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/msrule.php
+++ b/mailscanner/msrule.php
@@ -30,10 +30,7 @@
  */
 
 require_once __DIR__ . '/functions.php';
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
+
 require __DIR__ . '/login.function.php';
 
 if ($_SESSION['user_type'] !== 'A') {

--- a/mailscanner/mysql_status.php
+++ b/mailscanner/mysql_status.php
@@ -31,10 +31,6 @@
 
 require_once __DIR__ . '/functions.php';
 
-session_start();
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
 require __DIR__ . '/login.function.php';
 
 html_start(__('mysqlstatus31'), 0, false, false);

--- a/mailscanner/mysql_status.php
+++ b/mailscanner/mysql_status.php
@@ -32,6 +32,9 @@
 require_once __DIR__ . '/functions.php';
 
 session_start();
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 require __DIR__ . '/login.function.php';
 
 html_start(__('mysqlstatus31'), 0, false, false);

--- a/mailscanner/other.php
+++ b/mailscanner/other.php
@@ -33,10 +33,6 @@
 require_once __DIR__ . '/functions.php';
 
 // Authentication checking
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 html_start(__('toolslinks10'), '0', false, false);

--- a/mailscanner/other.php
+++ b/mailscanner/other.php
@@ -33,6 +33,9 @@
 require_once __DIR__ . '/functions.php';
 
 // Authentication checking
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/password_reset.php
+++ b/mailscanner/password_reset.php
@@ -34,10 +34,6 @@ require_once __DIR__ . '/functions.php';
 if (USE_LDAP === true) {
     die(__('pwdresetldap63'));
 }
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 
 if (PHP_SAPI !== 'cli' && SSL_ONLY && (!empty($_SERVER['PHP_SELF']))) {
     if (!$_SERVER['HTTPS'] === 'on') {

--- a/mailscanner/password_reset.php
+++ b/mailscanner/password_reset.php
@@ -34,7 +34,9 @@ require_once __DIR__ . '/functions.php';
 if (USE_LDAP === true) {
     die(__('pwdresetldap63'));
 }
-
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 
 if (PHP_SAPI !== 'cli' && SSL_ONLY && (!empty($_SERVER['PHP_SELF']))) {

--- a/mailscanner/postfixmailq.php
+++ b/mailscanner/postfixmailq.php
@@ -30,7 +30,9 @@
  */
 
 require_once __DIR__ . '/functions.php';
-
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/postfixmailq.php
+++ b/mailscanner/postfixmailq.php
@@ -30,10 +30,7 @@
  */
 
 require_once __DIR__ . '/functions.php';
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
+
 require __DIR__ . '/login.function.php';
 
 html_start(__('mqviewer32'));

--- a/mailscanner/quarantine.php
+++ b/mailscanner/quarantine.php
@@ -30,7 +30,9 @@
  */
 
 require_once __DIR__ . '/functions.php';
-
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/quarantine.php
+++ b/mailscanner/quarantine.php
@@ -30,10 +30,7 @@
  */
 
 require_once __DIR__ . '/functions.php';
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
+
 require __DIR__ . '/login.function.php';
 
 html_start(__('qviewer08'), 0, false, false);

--- a/mailscanner/quarantine_action.php
+++ b/mailscanner/quarantine_action.php
@@ -34,10 +34,7 @@
 */
 
 require_once __DIR__ . '/functions.php';
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
+
 require __DIR__ . '/login.function.php';
 
 function simple_html_start()

--- a/mailscanner/quarantine_action.php
+++ b/mailscanner/quarantine_action.php
@@ -34,7 +34,9 @@
 */
 
 require_once __DIR__ . '/functions.php';
-
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/rep_audit_log.php
+++ b/mailscanner/rep_audit_log.php
@@ -34,6 +34,9 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/rep_audit_log.php
+++ b/mailscanner/rep_audit_log.php
@@ -34,10 +34,6 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 // If the user isn't an administrator to send them back to the main page

--- a/mailscanner/rep_mcp_rule_hits.php
+++ b/mailscanner/rep_mcp_rule_hits.php
@@ -34,6 +34,9 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/rep_mcp_rule_hits.php
+++ b/mailscanner/rep_mcp_rule_hits.php
@@ -34,10 +34,6 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 // add the header information such as the logo, search, menu, ....

--- a/mailscanner/rep_mcp_score_dist.php
+++ b/mailscanner/rep_mcp_score_dist.php
@@ -34,6 +34,9 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/rep_mcp_score_dist.php
+++ b/mailscanner/rep_mcp_score_dist.php
@@ -34,10 +34,6 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 // add the header information such as the logo, search, menu, ....

--- a/mailscanner/rep_message_listing.php
+++ b/mailscanner/rep_message_listing.php
@@ -34,6 +34,9 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/rep_message_listing.php
+++ b/mailscanner/rep_message_listing.php
@@ -34,10 +34,6 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 // add the header information such as the logo, search, menu, ....

--- a/mailscanner/rep_message_ops.php
+++ b/mailscanner/rep_message_ops.php
@@ -34,6 +34,9 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/rep_message_ops.php
+++ b/mailscanner/rep_message_ops.php
@@ -34,10 +34,6 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 // add the header information such as the logo, search, menu, ....

--- a/mailscanner/rep_mrtg_style.php
+++ b/mailscanner/rep_mrtg_style.php
@@ -34,6 +34,9 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/rep_mrtg_style.php
+++ b/mailscanner/rep_mrtg_style.php
@@ -34,10 +34,6 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 // add the header information such as the logo, search, menu, ....

--- a/mailscanner/rep_sa_rule_hits.php
+++ b/mailscanner/rep_sa_rule_hits.php
@@ -34,6 +34,9 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/rep_sa_rule_hits.php
+++ b/mailscanner/rep_sa_rule_hits.php
@@ -34,10 +34,6 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 // add the header information such as the logo, search, menu, ....

--- a/mailscanner/rep_sa_score_dist.php
+++ b/mailscanner/rep_sa_score_dist.php
@@ -34,6 +34,9 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/rep_sa_score_dist.php
+++ b/mailscanner/rep_sa_score_dist.php
@@ -34,10 +34,6 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 // add the header information such as the logo, search, menu, ....

--- a/mailscanner/rep_top_mail_relays.php
+++ b/mailscanner/rep_top_mail_relays.php
@@ -34,6 +34,9 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/rep_top_mail_relays.php
+++ b/mailscanner/rep_top_mail_relays.php
@@ -34,10 +34,6 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 // add the header information such as the logo, search, menu, ....

--- a/mailscanner/rep_top_recipient_domains_by_quantity.php
+++ b/mailscanner/rep_top_recipient_domains_by_quantity.php
@@ -34,6 +34,9 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/rep_top_recipient_domains_by_quantity.php
+++ b/mailscanner/rep_top_recipient_domains_by_quantity.php
@@ -34,10 +34,6 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 // add the header information such as the logo, search, menu, ....

--- a/mailscanner/rep_top_recipient_domains_by_volume.php
+++ b/mailscanner/rep_top_recipient_domains_by_volume.php
@@ -34,6 +34,9 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/rep_top_recipient_domains_by_volume.php
+++ b/mailscanner/rep_top_recipient_domains_by_volume.php
@@ -34,10 +34,6 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 // add the header information such as the logo, search, menu, ....

--- a/mailscanner/rep_top_recipients_by_quantity.php
+++ b/mailscanner/rep_top_recipients_by_quantity.php
@@ -34,6 +34,9 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/rep_top_recipients_by_quantity.php
+++ b/mailscanner/rep_top_recipients_by_quantity.php
@@ -34,10 +34,6 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 // add the header information such as the logo, search, menu, ....

--- a/mailscanner/rep_top_recipients_by_volume.php
+++ b/mailscanner/rep_top_recipients_by_volume.php
@@ -34,6 +34,9 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/rep_top_recipients_by_volume.php
+++ b/mailscanner/rep_top_recipients_by_volume.php
@@ -34,10 +34,6 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 // add the header information such as the logo, search, menu, ....

--- a/mailscanner/rep_top_sender_domains_by_quantity.php
+++ b/mailscanner/rep_top_sender_domains_by_quantity.php
@@ -34,6 +34,9 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/rep_top_sender_domains_by_quantity.php
+++ b/mailscanner/rep_top_sender_domains_by_quantity.php
@@ -34,10 +34,6 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 // add the header information such as the logo, search, menu, ....

--- a/mailscanner/rep_top_sender_domains_by_volume.php
+++ b/mailscanner/rep_top_sender_domains_by_volume.php
@@ -34,6 +34,9 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/rep_top_sender_domains_by_volume.php
+++ b/mailscanner/rep_top_sender_domains_by_volume.php
@@ -34,10 +34,6 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 // add the header information such as the logo, search, menu, ....

--- a/mailscanner/rep_top_senders_by_quantity.php
+++ b/mailscanner/rep_top_senders_by_quantity.php
@@ -34,6 +34,9 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/rep_top_senders_by_quantity.php
+++ b/mailscanner/rep_top_senders_by_quantity.php
@@ -34,10 +34,6 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 // add the header information such as the logo, search, menu, ....

--- a/mailscanner/rep_top_senders_by_volume.php
+++ b/mailscanner/rep_top_senders_by_volume.php
@@ -34,6 +34,9 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/rep_top_senders_by_volume.php
+++ b/mailscanner/rep_top_senders_by_volume.php
@@ -34,10 +34,6 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 // add the header information such as the logo, search, menu, ....

--- a/mailscanner/rep_top_viruses.php
+++ b/mailscanner/rep_top_viruses.php
@@ -34,6 +34,9 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/rep_top_viruses.php
+++ b/mailscanner/rep_top_viruses.php
@@ -34,10 +34,6 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 // add the header information such as the logo, search, menu, ....

--- a/mailscanner/rep_total_mail_by_date.php
+++ b/mailscanner/rep_total_mail_by_date.php
@@ -34,6 +34,9 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/rep_total_mail_by_date.php
+++ b/mailscanner/rep_total_mail_by_date.php
@@ -34,10 +34,6 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 // add the header information such as the logo, search, menu, ....

--- a/mailscanner/rep_viruses.php
+++ b/mailscanner/rep_viruses.php
@@ -34,6 +34,9 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/rep_viruses.php
+++ b/mailscanner/rep_viruses.php
@@ -34,10 +34,6 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // Authentication checking
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 // add the header information such as the logo, search, menu, ....

--- a/mailscanner/reports.php
+++ b/mailscanner/reports.php
@@ -34,6 +34,9 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // verify login
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/reports.php
+++ b/mailscanner/reports.php
@@ -34,10 +34,6 @@ require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/filter.inc.php';
 
 // verify login
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 // Checking to see if there are any filters

--- a/mailscanner/sa_lint.php
+++ b/mailscanner/sa_lint.php
@@ -30,7 +30,9 @@
  */
 
 require_once __DIR__ . '/functions.php';
-
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/sa_lint.php
+++ b/mailscanner/sa_lint.php
@@ -30,10 +30,6 @@
  */
 
 require_once __DIR__ . '/functions.php';
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 html_start(__('salint51'), 0, false, false);

--- a/mailscanner/sa_rules_update.php
+++ b/mailscanner/sa_rules_update.php
@@ -30,7 +30,9 @@
  */
 
 require_once __DIR__ . '/functions.php';
-
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/sa_rules_update.php
+++ b/mailscanner/sa_rules_update.php
@@ -30,10 +30,7 @@
  */
 
 require_once __DIR__ . '/functions.php';
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
+
 require __DIR__ . '/login.function.php';
 
 if ($_SESSION['user_type'] !== 'A') {

--- a/mailscanner/sf_version.php
+++ b/mailscanner/sf_version.php
@@ -33,6 +33,9 @@
 require_once __DIR__ . '/functions.php';
 
 // Authentication checking
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/sf_version.php
+++ b/mailscanner/sf_version.php
@@ -33,10 +33,6 @@
 require_once __DIR__ . '/functions.php';
 
 // Authentication checking
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
 require __DIR__ . '/login.function.php';
 
 if ($_SESSION['user_type'] !== 'A') {

--- a/mailscanner/sophos_status.php
+++ b/mailscanner/sophos_status.php
@@ -30,10 +30,7 @@
  */
 
 require_once __DIR__ . '/functions.php';
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
+
 include __DIR__ . '/login.function.php';
 
 html_start(__('sophos53'), 0, false, false);

--- a/mailscanner/sophos_status.php
+++ b/mailscanner/sophos_status.php
@@ -30,7 +30,9 @@
  */
 
 require_once __DIR__ . '/functions.php';
-
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 include __DIR__ . '/login.function.php';
 

--- a/mailscanner/status.php
+++ b/mailscanner/status.php
@@ -30,10 +30,7 @@
  */
 
 require_once __DIR__ . '/functions.php';
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
+
 require __DIR__ . '/login.function.php';
 
 $refresh = html_start(__('recentmsg05'), STATUS_REFRESH, false, false);

--- a/mailscanner/status.php
+++ b/mailscanner/status.php
@@ -30,7 +30,9 @@
  */
 
 require_once __DIR__ . '/functions.php';
-
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/user_manager.php
+++ b/mailscanner/user_manager.php
@@ -35,7 +35,9 @@
 
 require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/lib/password.php';
-
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/user_manager.php
+++ b/mailscanner/user_manager.php
@@ -35,10 +35,7 @@
 
 require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/lib/password.php';
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
+
 require __DIR__ . '/login.function.php';
 
 html_start(__('usermgnt12'), 0, false, false);

--- a/mailscanner/viewmail.php
+++ b/mailscanner/viewmail.php
@@ -32,10 +32,7 @@
 require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/lib/pear/Mail/mimeDecode.php';
 ini_set('memory_limit', MEMORY_LIMIT);
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
+
 require __DIR__ . '/login.function.php';
 
 html_start(__('msgviewer06'), 0, false, false);

--- a/mailscanner/viewmail.php
+++ b/mailscanner/viewmail.php
@@ -32,7 +32,9 @@
 require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/lib/pear/Mail/mimeDecode.php';
 ini_set('memory_limit', MEMORY_LIMIT);
-
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 

--- a/mailscanner/viewpart.php
+++ b/mailscanner/viewpart.php
@@ -31,10 +31,7 @@
 
 require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/lib/pear/Mail/mimeDecode.php';
-if (defined('SESSION_NAME')) {
-    session_name(SESSION_NAME);
-}
-session_start();
+
 require __DIR__ . '/login.function.php';
 
 ini_set('memory_limit', MEMORY_LIMIT);

--- a/mailscanner/viewpart.php
+++ b/mailscanner/viewpart.php
@@ -31,7 +31,9 @@
 
 require_once __DIR__ . '/functions.php';
 require_once __DIR__ . '/lib/pear/Mail/mimeDecode.php';
-
+if (defined('SESSION_NAME')) {
+    session_name(SESSION_NAME);
+}
 session_start();
 require __DIR__ . '/login.function.php';
 


### PR DESCRIPTION
Fixes session conflict by setting `session_name`.  It has been reported on php.net that `session_name` can cause a performance hit, so I have made this optional in `conf.php` - see comments in `conf.php.example`

Fixes #730 