### PR TITLE
Fix PHP header warning for cli scripts

### DIFF
--- a/mailscanner/functions.php
+++ b/mailscanner/functions.php
@@ -127,10 +127,9 @@ if (PHP_SAPI !== 'cli') {
     header('X-XSS-Protection: 1; mode=block');
     header('X-Frame-Options: SAMEORIGIN');
     header('X-Content-Type-Options: nosniff');
+    unset($session_cookie_secure);
+    session_start();
 }
-
-unset($session_cookie_secure);
-session_start();
 
 // set default timezone
 date_default_timezone_set(TIME_ZONE);


### PR DESCRIPTION
Fixes the following warnings when running cli/maintenance scripts
```
PHP Warning:  session_start(): Cannot send session cookie - headers already sent by (output started at /var/www/html/mailscanner/conf.php:1) in /var/www/html/mailscanner/functions.php on line 133
PHP Warning:  session_start(): Cannot send session cache limiter - headers already sent (output started at /var/www/html/mailscanner/conf.php:1) in /var/www/html/mailscanner/functions.php on line 133
```