### PR TITLE
fix invalid colors for multiple y-axes in a line graph (fixes #926)

### DIFF
--- a/mailscanner/graphgenerator.inc.php
+++ b/mailscanner/graphgenerator.inc.php
@@ -109,7 +109,7 @@ class GraphGenerator
             $formattedData .= '[' . "\n";
             $dataLabels .= '[' . "\n";
             $graphTypes .= '[' . "\n";
-            $colors .= isset($this->settings['colors']) ? '["' . implode('", "', $this->settings['colors'][$i]) . '"]' : '';
+            $colors .= isset($this->settings['colors']) ? '["' . implode('", "', $this->settings['colors'][$i]) . '"],' : '';
             for ($j=0; $j<count($this->graphColumns['dataNumericColumns'][$i]); $j++) {
                 if (isset($this->graphColumns['dataLabels'][$i])) {
                     $dataLabels .= '"' . $this->graphColumns['dataLabels'][$i][$j] .'",';


### PR DESCRIPTION
The problem resulted in rep_total_mail_by_date.php not creating the graph when distributed setup or mcpchecks are enabled.